### PR TITLE
fix: 국어사전 url 갱신

### DIFF
--- a/workflow/info.plist
+++ b/workflow/info.plist
@@ -1529,7 +1529,7 @@
 				<key>spaces</key>
 				<string></string>
 				<key>url</key>
-				<string>https://krdic.naver.com/search.nhn?kind=all&amp;query={query}</string>
+				<string>https://ko.dict.naver.com/#/search?range=all&amp;query={query}</string>
 				<key>utf8</key>
 				<true/>
 			</dict>

--- a/workflow/krdic_naver_search.py
+++ b/workflow/krdic_naver_search.py
@@ -43,7 +43,7 @@ def main(wf):
     wf.add_item(title='Search Naver Krdic for \'%s\'' % args,
                 autocomplete=args,
                 arg=args,
-                quicklookurl='https://krdic.naver.com/search.nhn?kind=all&query=%s' % args,
+                quicklookurl='https://ko.dict.naver.com/#/search?query=%s' % args,
                 valid=True)
 
     def wrapper():
@@ -61,7 +61,7 @@ def main(wf):
                             arg=txt,
                             copytext=txt,
                             largetext=txt,
-                            quicklookurl='https://krdic.naver.com/search.nhn?kind=all&query=%s' % txt,
+                            quicklookurl='https://ko.dict.naver.com/#/search?query=%s' % txt,
                             valid=True)
 
     wf.send_feedback()


### PR DESCRIPTION
`krdic.naver.com`을 HTTP로 접근시에는 정상적으로 `ko.dict.naver.com`으로 리디렉션 되는데,
HTTPS로 접근시 `Connection refused` 에러가 발생하는 이슈가 확인되어 수정했습니다.