### PR TITLE
Fix: search Naver Map

### DIFF
--- a/workflow/naver_map.py
+++ b/workflow/naver_map.py
@@ -43,7 +43,7 @@ def get_data(word):
     headers = {"user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 12_4) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.4 Safari/605.1.15"}
     r = web.get(url, params, headers=headers)
     r.raise_for_status()
-    return r.json()
+    return r.json().get("all")
 
 def main(wf):
     args = wf.args[0]
@@ -59,8 +59,9 @@ def main(wf):
 
     res_json = wf.cached_data(f"navmap_{args}", wrapper, max_age=30)
 
-    if len(res_json["address"]) > 0:
-        for ltxt in res_json["address"]:
+    for item in res_json:
+        if item.get("address"):
+            ltxt = item["address"]
             address_key = "fullAddress"
             txt = ltxt[address_key]
             address = ltxt["title"]
@@ -76,8 +77,8 @@ def main(wf):
                 largetext=txt,
                 quicklookurl=f"https://map.naver.com/p/entry/{type}/{y},{x},{txt}",
                 valid=True)
-    elif len(res_json["place"]) > 0:
-        for ltxt in res_json["place"]:
+        elif item.get("place"):
+            ltxt = item["place"]
             address_key = "roadAddress"
             txt = ltxt["title"]
             if not ltxt.get(address_key):
@@ -94,8 +95,8 @@ def main(wf):
                 largetext=txt,
                 quicklookurl=f"https://map.naver.com/p/search/{txt}/{type}/{_id}",
                 valid=True)
-    elif len(res_json["bus"]) > 0:
-        for ltxt in res_json["bus"]:
+        elif item.get("bus"):
+            ltxt = item["bus"]
             type = "bus-route"
             address_key = ltxt["cityName"]
             txt = ltxt["title"]

--- a/workflow/naver_map.py
+++ b/workflow/naver_map.py
@@ -30,9 +30,7 @@ def get_ip_location():
     data = r.json()
     return data["lngLat"]
 
-def get_data(word):
-    locate = wf.cached_data('location_data', get_ip_location, max_age=30)
-
+def get_data(word, locate):
     url = 'https://map.naver.com/p/api/search/instant-search'
     params = dict(query=word,
                   type="all",
@@ -54,8 +52,9 @@ def main(wf):
                 quicklookurl=f"https://map.naver.com/p/search/{args}",
                 valid=True)
 
+    locate = wf.cached_data('location_data', get_ip_location, max_age=30)
     def wrapper():
-        return get_data(args)
+        return get_data(args, locate)
 
     res_json = wf.cached_data(f"navmap_{args}", wrapper, max_age=30)
 

--- a/workflow/naver_map.py
+++ b/workflow/naver_map.py
@@ -72,7 +72,7 @@ def main(wf):
                 subtitle=address,
                 autocomplete=txt,
                 arg=f"https://map.naver.com/p/entry/{type}/{y},{x},{txt}",
-                copytext=ltxt["fullAddress"],
+                copytext=txt,
                 largetext=txt,
                 quicklookurl=f"https://map.naver.com/p/entry/{type}/{y},{x},{txt}",
                 valid=True)

--- a/workflow/naver_map.py
+++ b/workflow/naver_map.py
@@ -64,15 +64,17 @@ def main(wf):
             address_key = "fullAddress"
             txt = ltxt[address_key]
             address = ltxt["title"]
-            type = ltxt["fullAddress"]
+            type = "address"
+            x = ltxt["x"]
+            y = ltxt["y"]
             wf.add_item(
                 title=f"Search Naver Map for \'{txt}\'",
                 subtitle=address,
                 autocomplete=txt,
-                arg=f"https://map.naver.com/p/search/{txt}/{type}",
-                copytext=txt,
+                arg=f"https://map.naver.com/p/entry/{type}/{y},{x},{txt}",
+                copytext=ltxt["fullAddress"],
                 largetext=txt,
-                quicklookurl=f"https://map.naver.com/p/search/{txt}/{type}",
+                quicklookurl=f"https://map.naver.com/p/entry/{type}/{y},{x},{txt}",
                 valid=True)
     elif len(res_json["place"]) > 0:
         for ltxt in res_json["place"]:

--- a/workflow/test_workflow.py
+++ b/workflow/test_workflow.py
@@ -9,6 +9,7 @@ import hanja_naver_search
 import endic_naver_search
 import enendic_naver_search
 import common_naver_search
+import naver_map
 
 
 class MyTestCase(unittest.TestCase):
@@ -57,6 +58,12 @@ class MyTestCase(unittest.TestCase):
             res = common_naver_search.get_dictionary_data(lang + 'ko', '한글')
 
             self.assertTrue(len(res['items']) > 0)
+
+    def test_naver_map(self):
+        locate = {'lat': '37.5665', 'lng': '126.9780'}
+        res = naver_map.get_data('서울', locate)
+
+        self.assertTrue((len(res) > 0))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Hotfix
naver map에서 Address 검색시 적절한 URL로 연결되지 않는 문제 해결  

## 개선
기존 : 네이버 맵 검색시 현재 Place, Address, Bus 등 모든 type이 아닌 하나의 type 위주로 반환
변경 : 검색어와 관련한 totalScore(map.naver.com/p/api 제공)에 따라 가장 근사치에 가까운 순으로 **모든 type의 결과**를 함께 반환